### PR TITLE
Catch unexpected signals in tests and mark them as failed

### DIFF
--- a/framework/cest
+++ b/framework/cest
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <csetjmp>
+#include <csignal>
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -60,6 +62,7 @@ std::stringstream assertion_failures;
 bool current_test_failed;
 cest::TestCase *current_test_case;
 cest::CommandLineOptions command_line_options;
+jmp_buf jump_env;
 
 
 namespace cest
@@ -523,6 +526,18 @@ namespace cest
         std::cout << "    -q/--quiet: Supress output (use only . and " << ASCII_RED << "F" << ASCII_RESET << " as output)";
         std::cout << std::endl;
     }
+
+    void onSignalRaised(int sig)
+    {
+        std::string signal_as_string(strsignal(sig));
+
+        current_test_failed = true;
+        current_test_case->failure_message = "Signal raised by test (" + signal_as_string + ")";
+
+        appendAssertionFailure(&assertion_failures, current_test_case->failure_message, current_test_case->file, current_test_case->line);
+
+        longjmp(jump_env, 1);
+    }
 }
 
 
@@ -540,6 +555,14 @@ int main(int argc, const char *argv[])
         return 0;
     }
 
+    signal(SIGSEGV, cest::onSignalRaised);
+    signal(SIGFPE, cest::onSignalRaised);
+    signal(SIGBUS, cest::onSignalRaised);
+    signal(SIGILL, cest::onSignalRaised);
+    signal(SIGTERM, cest::onSignalRaised);
+    signal(SIGXCPU, cest::onSignalRaised);
+    signal(SIGXFSZ, cest::onSignalRaised);
+
     test_suite.test_suite_name = test_suite_name;
     test_suite.test_cases = test_cases;
 
@@ -553,6 +576,7 @@ int main(int argc, const char *argv[])
 
         try {
             test_case->test();
+            setjmp(jump_env);
         } catch (AssertionError error) {
             handleFailedTest(test_case);
         } catch (ForcedPassError error) {


### PR DESCRIPTION
Closes #41 

In case a test raises an exception (Segmentation Fault, Floating Point Exception, Bus Conflict, Illegal Instruction, Terminate, CPU Quota Exceeded, File Storage Quota Exceeded) the signal is catched and the faulty test is marked as failed.