### PR TITLE
Catch unexpected signals in tests and mark them as failed

### DIFF
--- a/framework/cest
+++ b/framework/cest
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <csetjmp>
+#include <csignal>
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -60,6 +62,7 @@ std::stringstream assertion_failures;
 bool current_test_failed;
 cest::TestCase *current_test_case;
 cest::CommandLineOptions command_line_options;
+jmp_buf jump_env;
 
 
 namespace cest
@@ -523,6 +526,18 @@ namespace cest
         std::cout << "    -q/--quiet: Supress output (use only . and " << ASCII_RED << "F" << ASCII_RESET << " as output)";
         std::cout << std::endl;
     }
+
+    void onSignalRaised(int sig)
+    {
+        std::string signal_as_string(strsignal(sig));
+
+        current_test_failed = true;
+        current_test_case->failure_message = "Signal raised by test (" + signal_as_string + ")";
+
+        appendAssertionFailure(&assertion_failures, current_test_case->failure_message, current_test_case->file, current_test_case->line);
+
+        longjmp(jump_env, 1);
+    }
 }
 
 
@@ -540,6 +555,14 @@ int main(int argc, const char *argv[])
         return 0;
     }
 
+    signal(SIGSEGV, cest::onSignalRaised);
+    signal(SIGFPE, cest::onSignalRaised);
+    signal(SIGBUS, cest::onSignalRaised);
+    signal(SIGILL, cest::onSignalRaised);
+    signal(SIGTERM, cest::onSignalRaised);
+    signal(SIGXCPU, cest::onSignalRaised);
+    signal(SIGXFSZ, cest::onSignalRaised);
+
     test_suite.test_suite_name = test_suite_name;
     test_suite.test_cases = test_cases;
 
@@ -553,6 +576,7 @@ int main(int argc, const char *argv[])
 
         try {
             test_case->test();
+            setjmp(jump_env);
         } catch (AssertionError error) {
             handleFailedTest(test_case);
         } catch (ForcedPassError error) {


### PR DESCRIPTION
Closes #41 

Signals were not handled properly and the test runner would randomly crash when handling them. Now, given the following input test cases:

```cpp
it("will raise a segmentation fault", []() {
    int *a = (int *)0;

    *(a) = 10;
});

it("will raise a floating point exception", []() {
    int a = 0;
    int b = 0;
    std::cout << a / b;
});
```
The test runner detects the signals properly and marks tests as failed:
![image](https://user-images.githubusercontent.com/10237441/77293876-84d2b980-6ce3-11ea-91ec-d067d3f3e5c0.png)

JUnit XML report also marks tests as failed:

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites name="Cest Test Results" time="" tests="2" failures="2" disabled="" errors="">
    <testsuite name="a Cest test suite" tests="2" failures="2" time="" skipped="0" timestamp="" hostname="">
        <testcase name="will raise a segmentation fault" time="">
            <failure message="Signal raised by test (Segmentation fault)"/>
        </testcase>
        <testcase name="will raise a floating point exception" time="">
            <failure message="Signal raised by test (Floating point exception)"/>
        </testcase>
    </testsuite>
</testsuites>
```