### PR TITLE
Implement toMatch assertion with expected string and regex

### DIFF
--- a/framework/cest
+++ b/framework/cest
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <regex>
 
 #define ASCII_BACKGROUND_GREEN  "\u001b[42m"
 #define ASCII_BACKGROUND_RED    "\u001b[41m"
@@ -31,6 +32,7 @@
 #define afterAll(x)             cest::afterAllFunction(x)
 #define passTest()              cest::forcedPass()
 #define failTest()              cest::forcedFailure(__FILE__, __LINE__)
+#define Regex(x)                x, std::regex(x)
 
 
 namespace cest
@@ -311,6 +313,22 @@ namespace cest
                 }
             }
 
+            void toMatch(std::string expected)
+            {
+                toContain(expected);
+            }
+
+            void toMatch(std::string expected_string, std::regex expected)
+            {
+                if (!std::regex_search(actual, expected)) {
+                    current_test_failed = true;
+                    failure_message << "Expected pattern " << expected_string << " did not match with " << actual;
+                    current_test_case->failure_message = failure_message.str();
+
+                    appendAssertionFailure(&assertion_failures, current_test_case->failure_message, assertion_file, assertion_line);
+                }
+            }
+
             void toEqual(std::string expected)
             {
                 toBe(expected);
@@ -396,16 +414,25 @@ namespace cest
         return failed_tests;
     }
 
-    std::string sanitize(std::string text)
+    std::string replace_all(std::string text, std::string from, std::string to)
     {
-        int start=0;
-        std::string from("\"");
-        std::string to("\\\"");
+    int start=0;
 
         while ((start = text.find(from, start)) != std::string::npos) {
             text.replace(start, from.length(), to);
             start += to.length();
         }
+
+        return text;
+    }
+
+    std::string sanitize(std::string text)
+    {
+        std::string from("\"");
+        std::string to("\\\"");
+
+        text = replace_all(text, "\\", "\\\\");
+        text = replace_all(text, "\"", "\\\"");
 
         return text;
     }

--- a/spec/helpers/test_suite_report_samples.h
+++ b/spec/helpers/test_suite_report_samples.h
@@ -54,6 +54,26 @@ std::string sample_json_with_one_failed_test_case = "\
 }\
 ";
 
+std::string sample_json_with_one_failed_test_case_and_escaped_backslashes_and_double_quotes = "\
+{\
+\"name\":\"test something\",\
+\"tests\":1,\
+\"failures\":1,\
+\"errors\":0,\
+\"skipped\":0,\
+\"time\":\"\",\
+\"timestamp\":\"\",\
+\"hostname\":\"\",\
+\"test_cases\":[\
+{\
+\"name\":\"should fail\",\
+\"time\":\"\",\
+\"failure_message\":\"Expected pattern .*\\\\d+ apples did not match with I have 12 \\\"apples\"\
+}\
+]\
+}\
+";
+
 std::string sample_json_with_two_passed_test_cases = "\
 {\
 \"name\":\"test something\",\

--- a/spec/test_assertions.cpp
+++ b/spec/test_assertions.cpp
@@ -36,6 +36,18 @@ describe("test common assertions", []() {
         expect("cest").toHaveLength(4);
     });
 
+    it("asserts string matches", []() {
+        expect("hello").toMatch("hell");
+        expect("world").toMatch("orld");
+        expect("cest").toMatch("cest");
+    });
+
+    it("asserts regexs matches", []() {
+        expect("Hello world cest").toMatch(Regex("^Hell.*cest$"));
+        expect("I have 12 apples").toMatch(Regex(".*\\d+ apples"));
+        expect("To match a partial match").toMatch(Regex("\\w match$"));
+    });
+
     it("asserts pointers", []() {
         void *address = (void *)0xFA101132;
         char *string = (char *)"something";

--- a/spec/test_suite_result_generation.cpp
+++ b/spec/test_suite_result_generation.cpp
@@ -47,6 +47,21 @@ describe("test suite result generation", []() {
         expect(xml_report).toBe(sample_json_with_one_failed_test_case);
     });
 
+    it("generates a report when one test has failed containing backslash or double quotes", []() {
+        cest::TestCase test_case;
+        cest::TestSuite test_suite;
+
+        test_case.name = "should fail";
+        test_case.test_failed = true;
+        test_case.failure_message = "Expected pattern .*\\d+ apples did not match with I have 12 \"apples";
+        test_suite.test_suite_name = "test something";
+        test_suite.test_cases.push_back(&test_case);
+
+        auto xml_report = cest::generateSuiteReport(test_suite);
+
+        expect(xml_report).toBe(sample_json_with_one_failed_test_case_and_escaped_backslashes_and_double_quotes);
+    });
+
     it("generates a report when many tests have passed", []() {
         cest::TestCase first_test_case;
         cest::TestCase second_test_case;


### PR DESCRIPTION
Closes #7

Usage:
```cpp
// To match with string
Assert("My string").toMatch("string");

// To match with Regex
Assert("My string").toMatch(Regex("\\w \\w"));
```

* Jest `toMatch()` behavior has been preserved, allowing to use it with a `string` or `Regex`. [Ref](https://jestjs.io/docs/en/expect#tomatchregexporstring)
* `generateSuiteReport` now sanitizes unescaped backslashes.

`std::regex` instance does not expose its string pattern, I'm not sure if it would be better a class wrapping this.