### PR TITLE
Fix sign-compare and reorder warnings in compilation

### DIFF
--- a/framework/build.py
+++ b/framework/build.py
@@ -15,7 +15,7 @@ RESET = '\033[0m'
 
 def compile(test_name, files):
     binary = 'build/' + test_name
-    cmd = 'g++ -Ispec -Iinclude -Iframework -O0 -g {srcs} -o {obj}'.format(srcs=' '.join(files), obj=binary)
+    cmd = 'g++ -Wall -Ispec -Iinclude -Iframework -O0 -g {srcs} -o {obj}'.format(srcs=' '.join(files), obj=binary)
 
     if os.system(cmd) != 0:
         print RED + '❌ Build failed' + RESET

--- a/framework/cest
+++ b/framework/cest
@@ -44,11 +44,11 @@ namespace cest
         int line;
         std::function<void()> test;
         bool test_failed;
-        std::string failure_message;
         bool forced_pass;
         bool skip;
+        std::string failure_message;
 
-        TestCase() : skip(false), forced_pass(false), test_failed(false)
+        TestCase() : test_failed(false), forced_pass(false), skip(false)
         {
         }
     };

--- a/framework/cest
+++ b/framework/cest
@@ -253,7 +253,7 @@ namespace cest
                     throw AssertionError();
                 }
 
-                for (int i=0; i<expected.size(); ++i) {
+                for (size_t i=0; i<expected.size(); ++i) {
                     if (expected[i] != actual[i]) {
                         current_test_failed = true;
                         failure_message << "Vector item mismatch at position " << i << ", expected " << expected[i] << " but was " << actual[i];
@@ -274,7 +274,7 @@ namespace cest
             {
                 bool found = false;
 
-                for (int i=0; i<actual.size(); ++i) {
+                for (size_t i=0; i<actual.size(); ++i) {
                     if (actual[i] == item) {
                         found = true;
                         break;
@@ -291,7 +291,7 @@ namespace cest
                 }
             }
 
-            void toHaveLength(int size)
+            void toHaveLength(size_t size)
             {
                 if (actual.size() != size) {
                     current_test_failed = true;
@@ -366,7 +366,7 @@ namespace cest
                 }
             }
 
-            void toHaveLength(int64_t length)
+            void toHaveLength(size_t length)
             {
                 if (actual.length() != length) {
                     current_test_failed = true;
@@ -454,7 +454,7 @@ namespace cest
 
     std::string replace_all(std::string text, std::string from, std::string to)
     {
-    int start=0;
+    size_t start=0;
 
         while ((start = text.find(from, start)) != std::string::npos) {
             text.replace(start, from.length(), to);
@@ -492,7 +492,7 @@ namespace cest
 
         suite_report << "\"test_cases\":[";
 
-        for (int i=0; i<test_suite.test_cases.size(); ++i) {
+        for (size_t i=0; i<test_suite.test_cases.size(); ++i) {
             suite_report << "{";
             emitStringField(&suite_report, "name", test_suite.test_cases[i]->name, true);
             emitStringField(&suite_report, "time", "", test_suite.test_cases[i]->test_failed || test_suite.test_cases[i]->skip);

--- a/spec/test_greeting.cpp
+++ b/spec/test_greeting.cpp
@@ -29,7 +29,7 @@ string Greet(string name)
 
 string greetManyPeople(vector<string> names)
 {
-    int i;
+    size_t i;
     string greeting = "Hello ";
 
     for (i=0; i<names.size(); ++i) {


### PR DESCRIPTION
Closes #57 

<details>
<summary>Without fixes and enabling all warnings</summary>

```shell
Building tests and sources
In file included from spec/test_greeting.cpp:1:0:
framework/cest: In constructor ‘cest::TestCase::TestCase()’:
framework/cest:49:14: warning: ‘cest::TestCase::skip’ will be initialized after [-Wreorder]
         bool skip;
              ^~~~
framework/cest:48:14: warning:   ‘bool cest::TestCase::forced_pass’ [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
framework/cest:48:14: warning: ‘cest::TestCase::forced_pass’ will be initialized after [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:46:14: warning:   ‘bool cest::TestCase::test_failed’ [-Wreorder]
         bool test_failed;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
spec/test_greeting.cpp: In function ‘std::__cxx11::string greetManyPeople(std::vector<std::__cxx11::basic_string<char> >)’:
spec/test_greeting.cpp:35:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (i=0; i<names.size(); ++i) {
               ~^~~~~~~~~~~~~
spec/test_greeting.cpp:36:15: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (i == names.size() - 1) {
             ~~^~~~~~~~~~~~~~~~~~~
spec/test_greeting.cpp:38:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         } else if (i == names.size() - 2) {
                    ~~^~~~~~~~~~~~~~~~~~~
In file included from spec/test_money.cpp:1:0:
framework/cest: In constructor ‘cest::TestCase::TestCase()’:
framework/cest:49:14: warning: ‘cest::TestCase::skip’ will be initialized after [-Wreorder]
         bool skip;
              ^~~~
framework/cest:48:14: warning:   ‘bool cest::TestCase::forced_pass’ [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
framework/cest:48:14: warning: ‘cest::TestCase::forced_pass’ will be initialized after [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:46:14: warning:   ‘bool cest::TestCase::test_failed’ [-Wreorder]
         bool test_failed;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
In file included from spec/test_assertions.cpp:1:0:
framework/cest: In constructor ‘cest::TestCase::TestCase()’:
framework/cest:49:14: warning: ‘cest::TestCase::skip’ will be initialized after [-Wreorder]
         bool skip;
              ^~~~
framework/cest:48:14: warning:   ‘bool cest::TestCase::forced_pass’ [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
framework/cest:48:14: warning: ‘cest::TestCase::forced_pass’ will be initialized after [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:46:14: warning:   ‘bool cest::TestCase::test_failed’ [-Wreorder]
         bool test_failed;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
In file included from spec/test_suite_result_generation.cpp:1:0:
framework/cest: In constructor ‘cest::TestCase::TestCase()’:
framework/cest:49:14: warning: ‘cest::TestCase::skip’ will be initialized after [-Wreorder]
         bool skip;
              ^~~~
framework/cest:48:14: warning:   ‘bool cest::TestCase::forced_pass’ [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
framework/cest:48:14: warning: ‘cest::TestCase::forced_pass’ will be initialized after [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:46:14: warning:   ‘bool cest::TestCase::test_failed’ [-Wreorder]
         bool test_failed;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
In file included from spec/test_description.cpp:1:0:
framework/cest: In constructor ‘cest::TestCase::TestCase()’:
framework/cest:49:14: warning: ‘cest::TestCase::skip’ will be initialized after [-Wreorder]
         bool skip;
              ^~~~
framework/cest:48:14: warning:   ‘bool cest::TestCase::forced_pass’ [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
framework/cest:48:14: warning: ‘cest::TestCase::forced_pass’ will be initialized after [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:46:14: warning:   ‘bool cest::TestCase::test_failed’ [-Wreorder]
         bool test_failed;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
In file included from spec/test_command_line_arguments.cpp:1:0:
framework/cest: In constructor ‘cest::TestCase::TestCase()’:
framework/cest:49:14: warning: ‘cest::TestCase::skip’ will be initialized after [-Wreorder]
         bool skip;
              ^~~~
framework/cest:48:14: warning:   ‘bool cest::TestCase::forced_pass’ [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
framework/cest:48:14: warning: ‘cest::TestCase::forced_pass’ will be initialized after [-Wreorder]
         bool forced_pass;
              ^~~~~~~~~~~
framework/cest:46:14: warning:   ‘bool cest::TestCase::test_failed’ [-Wreorder]
         bool test_failed;
              ^~~~~~~~~~~
framework/cest:51:9: warning:   when initialized here [-Wreorder]
         TestCase() : skip(false), forced_pass(false), test_failed(false)
         ^~~~~~~~
 PASS  spec/test_greeting.cpp:133 it should greet my friend when name is empty
 PASS  spec/test_greeting.cpp:133 it should greet
 PASS  spec/test_greeting.cpp:133 it should greet shouting when name is uppercase
 PASS  spec/test_greeting.cpp:133 it should greet my friend when greeting an empty list of names
 PASS  spec/test_greeting.cpp:133 it should greet a list of names with one name
 PASS  spec/test_greeting.cpp:133 it should greet two people
 PASS  spec/test_greeting.cpp:133 it should greet many people
 PASS  spec/test_money.cpp:209 it converts 0E to coins
 PASS  spec/test_money.cpp:209 it converts 1E to coins
 PASS  spec/test_money.cpp:209 it converts 2E to coins
 PASS  spec/test_money.cpp:209 it converts 3E to coins
 PASS  spec/test_money.cpp:209 it converts 4E to coins
 PASS  spec/test_money.cpp:209 it converts 213E to coins
 PASS  spec/test_money.cpp:209 it rejects negative amounts
 PASS  spec/test_money.cpp:209 it rejects amounts not in Euro
 PASS  spec/test_assertions.cpp:76 it asserts booleans
 PASS  spec/test_assertions.cpp:76 it asserts integers
 PASS  spec/test_assertions.cpp:76 it asserts strings
 PASS  spec/test_assertions.cpp:76 it asserts string matches
 PASS  spec/test_assertions.cpp:76 it asserts regexs matches
 PASS  spec/test_assertions.cpp:76 it asserts pointers
 PASS  spec/test_assertions.cpp:76 it asserts lists
 PASS  spec/test_assertions.cpp:76 it can be forced to always pass
 PASS  spec/test_suite_result_generation.cpp:123 it generates an empty report when no tests have been executed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has passed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has failed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has failed containing backslash or double quotes
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when many tests have passed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when many tests have passed and failed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has been skipped
 PASS  spec/test_description.cpp:18 it can contain test cases
 PASS  spec/test_description.cpp:18 it can also have test cases with unicode symbols 😀
 SKIP  spec/test_description.cpp:18 it can be skipped
 PASS  spec/test_command_line_arguments.cpp:54 it will use default behaviour if empty
 PASS  spec/test_command_line_arguments.cpp:54 it will supress output if --quiet is present
 PASS  spec/test_command_line_arguments.cpp:54 it will supress output if -q is present
 PASS  spec/test_command_line_arguments.cpp:54 it will show help if --help is present
 PASS  spec/test_command_line_arguments.cpp:54 it will show help if -h is present

```
</details>

<details>
<summary>After applying fixes</summary>

```shell
jamoh@jamoh-pc:~/github/cest(review-warning-compilations)$ make
Building tests and sources
 PASS  spec/test_greeting.cpp:133 it should greet my friend when name is empty
 PASS  spec/test_greeting.cpp:133 it should greet
 PASS  spec/test_greeting.cpp:133 it should greet shouting when name is uppercase
 PASS  spec/test_greeting.cpp:133 it should greet my friend when greeting an empty list of names
 PASS  spec/test_greeting.cpp:133 it should greet a list of names with one name
 PASS  spec/test_greeting.cpp:133 it should greet two people
 PASS  spec/test_greeting.cpp:133 it should greet many people
 PASS  spec/test_money.cpp:209 it converts 0E to coins
 PASS  spec/test_money.cpp:209 it converts 1E to coins
 PASS  spec/test_money.cpp:209 it converts 2E to coins
 PASS  spec/test_money.cpp:209 it converts 3E to coins
 PASS  spec/test_money.cpp:209 it converts 4E to coins
 PASS  spec/test_money.cpp:209 it converts 213E to coins
 PASS  spec/test_money.cpp:209 it rejects negative amounts
 PASS  spec/test_money.cpp:209 it rejects amounts not in Euro
 PASS  spec/test_assertions.cpp:76 it asserts booleans
 PASS  spec/test_assertions.cpp:76 it asserts integers
 PASS  spec/test_assertions.cpp:76 it asserts strings
 PASS  spec/test_assertions.cpp:76 it asserts string matches
 PASS  spec/test_assertions.cpp:76 it asserts regexs matches
 PASS  spec/test_assertions.cpp:76 it asserts pointers
 PASS  spec/test_assertions.cpp:76 it asserts lists
 PASS  spec/test_assertions.cpp:76 it can be forced to always pass
 PASS  spec/test_suite_result_generation.cpp:123 it generates an empty report when no tests have been executed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has passed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has failed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has failed containing backslash or double quotes
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when many tests have passed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when many tests have passed and failed
 PASS  spec/test_suite_result_generation.cpp:123 it generates a report when one test has been skipped
 PASS  spec/test_description.cpp:18 it can contain test cases
 PASS  spec/test_description.cpp:18 it can also have test cases with unicode symbols 😀
 SKIP  spec/test_description.cpp:18 it can be skipped
 PASS  spec/test_command_line_arguments.cpp:54 it will use default behaviour if empty
 PASS  spec/test_command_line_arguments.cpp:54 it will supress output if --quiet is present
 PASS  spec/test_command_line_arguments.cpp:54 it will supress output if -q is present
 PASS  spec/test_command_line_arguments.cpp:54 it will show help if --help is present
 PASS  spec/test_command_line_arguments.cpp:54 it will show help if -h is present
```
</details>