### PR TITLE
Support asserting exceptions

### DIFF
--- a/framework/cest
+++ b/framework/cest
@@ -151,6 +151,27 @@ namespace cest
         (*stream) << "                        " << file << ":" << line << std::endl;
     }
 
+    template<class T>
+    void assertRaises(std::function<void()> expression)
+    {
+        int line = current_test_case->line;
+        std::string file = current_test_case->file;
+
+        try {
+            expression();
+        } catch (const T& err) {
+            return;
+        } catch (const std::exception& err) {
+            current_test_failed = true;
+            current_test_case->failure_message = "Expected exception not raised";
+            appendAssertionFailure(&assertion_failures, current_test_case->failure_message, file, line);
+        }
+
+        current_test_failed = true;
+        current_test_case->failure_message = "Expected exception not raised";
+        appendAssertionFailure(&assertion_failures, current_test_case->failure_message, file, line);
+    }
+
     void forcedFailure(std::string file, int line)
     {
         current_test_failed = true;

--- a/spec/test_assertions.cpp
+++ b/spec/test_assertions.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <example.h>
 
+using namespace cest;
 
 describe("test common assertions", []() {
     beforeEach([]() {
@@ -72,5 +73,13 @@ describe("test common assertions", []() {
         passTest();
 
         expect(false).toBe(true);
+    });
+
+    it("can assert exceptions", []() {
+        std::string number = "potato";
+
+        assertRaises<std::invalid_argument>([=]() {
+            std::stoi(number);
+        });
     });
 });


### PR DESCRIPTION
New keyword `assertRaises` should let assert the raise of an exception. If the lambda expression throws the expected exception, assertion passes. Fails otherwise.

```cpp
describe("test", []() {
  it("raises an exception", []() {
    assertRaises<std::invalid_argument>([]() {
      std::stoi("apple");
    });
  });
});
```