### PR TITLE
Add support for parametrized test cases

### DIFF
--- a/framework/cest
+++ b/framework/cest
@@ -145,31 +145,36 @@ namespace cest
         throw ForcedPassError();
     }
 
+    template <class T>
+    class Parameter {
+        public:
+            Parameter() {}
+
+            Parameter<T> withValue(T v) {
+                values.push_back(v);
+                return *this;
+            }
+
+            void thenDo(std::function<void(T)> call) {
+                for (T v : values) {
+                    call(v);
+                }
+            }
+
+        private:
+            std::vector<T> values;
+    };
+
+    template <class T>
+    Parameter<T> withParameter()
+    {
+        return Parameter<T>();
+    }
+
     void appendAssertionFailure(std::stringstream *stream, std::string message, std::string file, int line)
     {
         (*stream) << ASCII_RED << "    ❌ Assertion Failed:" << ASCII_RESET << " " << message << std::endl;
         (*stream) << "                        " << file << ":" << line << std::endl;
-    }
-
-    template<class T>
-    void assertRaises(std::function<void()> expression)
-    {
-        int line = current_test_case->line;
-        std::string file = current_test_case->file;
-
-        try {
-            expression();
-        } catch (const T& err) {
-            return;
-        } catch (const std::exception& err) {
-            current_test_failed = true;
-            current_test_case->failure_message = "Expected exception not raised";
-            appendAssertionFailure(&assertion_failures, current_test_case->failure_message, file, line);
-        }
-
-        current_test_failed = true;
-        current_test_case->failure_message = "Expected exception not raised";
-        appendAssertionFailure(&assertion_failures, current_test_case->failure_message, file, line);
     }
 
     void forcedFailure(std::string file, int line)
@@ -203,6 +208,27 @@ namespace cest
     }
 
     template<class T>
+    void assertRaises(std::function<void()> expression)
+    {
+        int line = current_test_case->line;
+        std::string file = current_test_case->file;
+
+        try {
+            expression();
+        } catch (const T& err) {
+            return;
+        } catch (const std::exception& err) {
+            current_test_failed = true;
+            current_test_case->failure_message = "Expected exception not raised";
+            appendAssertionFailure(&assertion_failures, current_test_case->failure_message, file, line);
+        }
+
+        current_test_failed = true;
+        current_test_case->failure_message = "Expected exception not raised";
+        appendAssertionFailure(&assertion_failures, current_test_case->failure_message, file, line);
+    }
+
+    template<class T>
     class Assertion
     {
         public:
@@ -211,6 +237,30 @@ namespace cest
                 actual = value;
                 assertion_file = std::string(file);
                 assertion_line = line;
+            }
+
+            void toBeTruthy()
+            {
+                if (!actual) {
+                    current_test_failed = true;
+                    failure_message << "Expresion is not truthy";
+                    current_test_case->failure_message = failure_message.str();
+
+                    appendAssertionFailure(&assertion_failures, current_test_case->failure_message, assertion_file, assertion_line);
+                    throw AssertionError();
+                }
+            }
+
+            void toBeFalsy()
+            {
+                if (actual) {
+                    current_test_failed = true;
+                    failure_message << "Expresion is not falsy";
+                    current_test_case->failure_message = failure_message.str();
+
+                    appendAssertionFailure(&assertion_failures, current_test_case->failure_message, assertion_file, assertion_line);
+                    throw AssertionError();
+                }
             }
 
             void toBe(T expected)

--- a/spec/test_parametrized_tests.cpp
+++ b/spec/test_parametrized_tests.cpp
@@ -1,0 +1,47 @@
+#include <cest>
+
+using namespace std;
+using namespace cest;
+
+describe("parametrized tests", []() {
+    it("can make use of integer parameters", []() {
+        withParameter<int>().
+            withValue(10).
+            withValue(20).
+            withValue(30).
+            thenDo([](int x) {
+                expect(x > 0).toBeTruthy();
+            });
+    });
+
+    it("can make use of string parameters", []() {
+        withParameter<std::string>().
+            withValue("hello cat").
+            withValue("hello dog").
+            withValue("hello cest").
+            thenDo([](std::string x) {
+                expect(x).toContain("hello");
+            });
+    });
+
+    it("can be used with classes", []() {
+        typedef std::pair<int, std::string> HttpStatusCode;
+
+        auto statusCodeCategory = [](HttpStatusCode status_code) {
+            if (status_code.first >= 400 && status_code.first <= 499) {
+                return std::string("Client Error");
+            }
+
+            return std::string("Unknown");
+        };
+
+        withParameter<HttpStatusCode>().
+            withValue(HttpStatusCode(400, "Bad Request")).
+            withValue(HttpStatusCode(403, "Forbidden")).
+            withValue(HttpStatusCode(404, "Not Found")).
+            withValue(HttpStatusCode(409, "Conflict")).
+            thenDo([=](HttpStatusCode x) {
+                expect(statusCodeCategory(x)).toBe("Client Error");
+            });
+    });
+});

--- a/spec/test_roman_to_arabic_converter.cpp
+++ b/spec/test_roman_to_arabic_converter.cpp
@@ -1,0 +1,96 @@
+/*
+  Ported from Sandro Mancuso's Roman numerals kata,
+  to describe parametrized tests API in Cest
+
+  https://github.com/sandromancuso/roman-numerals-kata
+*/
+#include <cest>
+
+using namespace cest;
+
+
+class ArabicToRoman {
+    public:
+        ArabicToRoman(int arabic, std::string roman) {
+            this->arabic = arabic;
+            this->roman = roman;
+        }
+
+        int arabic;
+        std::string roman;
+};
+
+std::vector<ArabicToRoman> arabicToRoman; 
+
+ArabicToRoman THOUSAND(1000, "M");
+ArabicToRoman NINE_HUNDRED(900, "CM");
+ArabicToRoman FIVE_HUNDRED(500, "D");
+ArabicToRoman FOUR_HUNDRED(400, "CD");
+ArabicToRoman HUNDRED(100, "C");
+ArabicToRoman NINETY(90, "XC");
+ArabicToRoman FIFTY(50, "L");
+ArabicToRoman FORTY(40, "XL");
+ArabicToRoman TEN(10, "X");
+ArabicToRoman NINE(9, "IX");
+ArabicToRoman FIVE(5, "V");
+ArabicToRoman FOUR(4, "IV");
+ArabicToRoman ONE(1, "I");
+
+void initialize() {
+    arabicToRoman.clear();
+
+    arabicToRoman.push_back(THOUSAND);
+    arabicToRoman.push_back(NINE_HUNDRED);
+    arabicToRoman.push_back(FIVE_HUNDRED);
+    arabicToRoman.push_back(FOUR_HUNDRED);
+    arabicToRoman.push_back(HUNDRED);
+    arabicToRoman.push_back(NINETY);
+    arabicToRoman.push_back(FIFTY);
+    arabicToRoman.push_back(FORTY);
+    arabicToRoman.push_back(TEN);
+    arabicToRoman.push_back(NINE);
+    arabicToRoman.push_back(FIVE);
+    arabicToRoman.push_back(FOUR);
+    arabicToRoman.push_back(ONE);
+}
+
+namespace ArabicToRomanConverter {
+    std::string romanFor(int arabic) {
+        std::string roman = "";
+
+        for (ArabicToRoman value : arabicToRoman) {
+            while (arabic >= value.arabic) {
+                roman.append(value.roman);
+                arabic -= value.arabic;
+            }
+        }
+
+        return roman;
+    }
+}
+
+describe("Roman to arabic numeral converter", []() {
+    beforeAll([&]() {
+        initialize();
+    });
+
+    it("converts arabic numbers into their respective roman numerals", [&]() {
+        withParameter<ArabicToRoman>().
+            withValue(ArabicToRoman(1, "I")).
+            withValue(ArabicToRoman(2, "II")).
+            withValue(ArabicToRoman(3, "III")).
+            withValue(ArabicToRoman(4, "IV")).
+            withValue(ArabicToRoman(5, "V")).
+            withValue(ArabicToRoman(7, "VII")).
+            withValue(ArabicToRoman(9, "IX")).
+            withValue(ArabicToRoman(10, "X")).
+            withValue(ArabicToRoman(17, "XVII")).
+            withValue(ArabicToRoman(30, "XXX")).
+            withValue(ArabicToRoman(38, "XXXVIII")).
+            withValue(ArabicToRoman(479, "CDLXXIX")).
+            withValue(ArabicToRoman(3999, "MMMCMXCIX")).
+            thenDo([&](ArabicToRoman x) {
+                expect(ArabicToRomanConverter::romanFor(x.arabic)).toBe(x.roman);
+            });
+    });
+});


### PR DESCRIPTION
Closes #63 

This PR adds support for parametrized tests. Check `test_parametrized_tests.cpp` and `test_roman_to_arabic_converter.cpp` for usage examples.