### PR TITLE
fix(process): out-of-bounds write when reading child process output

### DIFF
--- a/runner/process.cpp
+++ b/runner/process.cpp
@@ -49,11 +49,11 @@ static int handleParentProcess(int pipe_fd[2], std::function<void(std::string)> 
   do
   {
     std::array<char, MAX_BUFFER> buffer;
-    buffer.fill('\0');
     read_bytes = read(pipe_fd[0], buffer.data(), buffer.size());
-    buffer[read_bytes + 1] = '\0';
-    output += buffer.data();
-  } while (read_bytes != 0);
+    if (read_bytes > 0) {
+      output.append(buffer.data(), read_bytes);
+    }
+  } while (read_bytes > 0);
 
   on_output(output);
 


### PR DESCRIPTION
`read()` can return up to `buffer.size()` (4096) bytes, so `buffer[read_bytes + 1] = '\0'` wrote past the end of the 4096-byte stack array — a stack buffer overflow when a child filled the buffer. Under ASan this surfaces as `stack-buffer-overflow`; without it, undefined behavior.

Fix: append exactly `read_bytes` bytes to the output string and drop the manual null terminator. Also stop the read loop on error (`read()` returning `-1`) instead of looping forever.