### PR TITLE
fix(suites): restore describe scope, allow sibling top-level suites and reject duplicate names

### DIFF
--- a/src/focus-test-suite.hpp
+++ b/src/focus-test-suite.hpp
@@ -27,7 +27,7 @@ namespace cest
       }
     }
 
-    for (auto &pair : test_suite->test_suites)
-      configureFocusedTestSuite(pair.second);
+    for (cest::TestSuite *nested_suite : test_suite->test_suites)
+      configureFocusedTestSuite(nested_suite);
   }
 }

--- a/src/json-output.hpp
+++ b/src/json-output.hpp
@@ -10,6 +10,16 @@ namespace cest
     cest::TestSuite *test_suite,
     nlohmann::json& output)
   {
+    bool is_root = test_suite == &__cest_globals.root_test_suite;
+
+    if (is_root)
+    {
+      for (cest::TestSuite *nested_suite : test_suite->test_suites)
+        addSuiteJsonResult(nested_suite, output);
+
+      return;
+    }
+
     nlohmann::json suite;
 
     suite["tests"] = std::vector<nlohmann::json>();
@@ -32,8 +42,8 @@ namespace cest
 
     output["suites"].push_back(suite);
 
-    for (auto &pair : test_suite->test_suites)
-      addSuiteJsonResult(pair.second, output);
+    for (cest::TestSuite *nested_suite : test_suite->test_suites)
+      addSuiteJsonResult(nested_suite, output);
   }
 
   void dumpJsonResult(cest::TestSuite *root_suite)
@@ -55,8 +65,8 @@ namespace cest
     for (auto &test_case : test_suite->test_cases)
       output["test_cases"].push_back(test_case->name);
 
-    for (auto &pair : test_suite->test_suites)
-      addSuiteJsonTestCases(pair.second, output);
+    for (cest::TestSuite *nested_suite : test_suite->test_suites)
+      addSuiteJsonTestCases(nested_suite, output);
   }
 
   void dumpJsonTestList(cest::TestSuite *root_suite)

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -35,6 +35,14 @@ int main(int argc, const char *argv[])
     return 0;
   }
 
+  if (!__cest_globals.registration_errors.empty())
+  {
+    for (const std::string &error : __cest_globals.registration_errors)
+      std::cout << error << std::endl;
+
+    return 1;
+  }
+
   if (command_line_options.print_test_list)
   {
     cest::dumpJsonTestList(root_suite);

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -106,12 +106,22 @@ namespace cest
     for (cest::TestCase *test_case : suite->test_cases)
       printTestCaseResult(test_case);
 
-    for (auto &pair : suite->test_suites)
-      printTestSuiteResult(pair.second);
+    for (cest::TestSuite *nested_suite : suite->test_suites)
+      printTestSuiteResult(nested_suite);
   }
 
   void printTreeSuiteResult(cest::TestSuite *suite, int indentation = 0)
   {
+    bool is_root = suite == &__cest_globals.root_test_suite;
+
+    if (is_root)
+    {
+      for (cest::TestSuite *nested_suite : suite->test_suites)
+        printTreeSuiteResult(nested_suite, indentation);
+
+      return;
+    }
+
     std::string spacing = "  ";
 
     for (int i = 0; i < indentation; ++i)
@@ -138,8 +148,8 @@ namespace cest
       }
     }
 
-    for (auto &pair : suite->test_suites)
-      printTreeSuiteResult(pair.second, indentation + 1);
+    for (cest::TestSuite *nested_suite : suite->test_suites)
+      printTreeSuiteResult(nested_suite, indentation + 1);
   }
 
   void printSuiteSummaryResult(cest::TestSuite *suite)

--- a/src/randomized-tests.hpp
+++ b/src/randomized-tests.hpp
@@ -14,7 +14,7 @@ namespace cest
   {
     random_fn(seed, suite);
 
-    for (auto &pair : suite->test_suites)
-      randomizeTests(pair.second, seed, random_fn);
+    for (cest::TestSuite *nested_suite : suite->test_suites)
+      randomizeTests(nested_suite, seed, random_fn);
   }
 }

--- a/src/suite-runner.hpp
+++ b/src/suite-runner.hpp
@@ -70,8 +70,8 @@ namespace cest
     if (suite->after_all.fn)
       suite->after_all.fn();
 
-    for (auto &pair : suite->test_suites)
-      runTestSuite(pair.second);
+    for (cest::TestSuite *nested_suite : suite->test_suites)
+      runTestSuite(nested_suite);
   }
 
   void cleanUpSingleSuite(
@@ -85,8 +85,8 @@ namespace cest
     for (const auto test : test_suite->test_cases)
       tests_to_delete.push_back(test);
 
-    for (auto &pair : test_suite->test_suites)
-      cleanUpSingleSuite(pair.second, suites_to_delete, tests_to_delete);
+    for (cest::TestSuite *nested_suite : test_suite->test_suites)
+      cleanUpSingleSuite(nested_suite, suites_to_delete, tests_to_delete);
   }
 
   void cleanUpTestSuite(cest::TestSuite *test_suite)

--- a/src/test-builder.hpp
+++ b/src/test-builder.hpp
@@ -51,22 +51,37 @@ namespace cest
     }
   };
 
+  bool suiteNameAlreadyUsed(TestSuite *parent, const std::string &name)
+  {
+    for (TestSuite *sibling : parent->test_suites)
+    {
+      if (sibling->name == name)
+        return true;
+    }
+
+    return false;
+  }
+
   int describeFn(std::string name, std::function<void()> fn)
   {
-    if (__cest_globals.current_test_suite == nullptr)
+    TestSuite *parent = &__cest_globals.root_test_suite;
+
+    if (__cest_globals.current_test_suite != nullptr)
+      parent = __cest_globals.current_test_suite;
+
+    if (suiteNameAlreadyUsed(parent, name))
     {
-      __cest_globals.current_test_suite = &__cest_globals.root_test_suite;
-    }
-    else
-    {
-      TestSuite *new_suite = new TestSuite();
-      __cest_globals.current_test_suite->test_suites[name] = new_suite;
-      __cest_globals.current_test_suite = new_suite;
+      __cest_globals.registration_errors.push_back(
+        "Duplicate test suite name \"" + name + "\" at the same level.");
     }
 
-    __cest_globals.current_test_suite->name = name;
+    TestSuite *suite = new TestSuite();
+    suite->name = name;
+    parent->test_suites.push_back(suite);
 
+    __cest_globals.current_test_suite = suite;
     fn();
+    __cest_globals.current_test_suite = parent;
 
     return 0;
   }

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <functional>
 #include <map>
+#include <vector>
 #include <string>
 #include <csetjmp>
 
@@ -39,7 +40,7 @@ namespace cest
     TestFunction before_all;
     TestFunction after_all;
     std::vector<TestCase *> test_cases;
-    std::map<std::string, TestSuite *> test_suites;
+    std::vector<TestSuite *> test_suites;
   };
 
   class AssertionError : public std::exception
@@ -86,6 +87,7 @@ namespace cest
     jmp_buf jump_env;
     bool leaks_detected;
     int saved_stderr;
+    std::vector<std::string> registration_errors;
 
     CestGlobals() :
       current_test_suite(nullptr),
@@ -105,8 +107,8 @@ namespace cest
       }
     }
 
-    for (auto &pair : suite->test_suites)
-      any_test_failed |= anyTestInSuiteFailed(pair.second);
+    for (cest::TestSuite *nested_suite : suite->test_suites)
+      any_test_failed |= anyTestInSuiteFailed(nested_suite);
 
     return any_test_failed;
   }
@@ -121,8 +123,8 @@ namespace cest
         num_tests++;
     }
 
-    for (auto &pair : suite->test_suites)
-      num_tests += countTestsMatching(pair.second, condition);
+    for (cest::TestSuite *nested_suite : suite->test_suites)
+      num_tests += countTestsMatching(nested_suite, condition);
 
     return num_tests;
   }
@@ -156,8 +158,8 @@ namespace cest
     }
     else
     {
-      for (const auto &pair : suite->test_suites)
-        return findSuiteSourceFile(pair.second);
+      for (cest::TestSuite *nested_suite : suite->test_suites)
+        return findSuiteSourceFile(nested_suite);
     }
 
     return "";
@@ -173,9 +175,9 @@ namespace cest
         out.push_back(test_case);
     }
 
-    for (const auto &pair : suite->test_suites)
+    for (cest::TestSuite *nested_suite : suite->test_suites)
     {
-      auto nested = findFailedTestCases(pair.second);
+      auto nested = findFailedTestCases(nested_suite);
       out.insert(out.end(), nested.begin(), nested.end());
     }
 

--- a/test/framework/nested-suites.test.cpp
+++ b/test/framework/nested-suites.test.cpp
@@ -24,4 +24,8 @@ describe("the first test suite", []() {
       expect(v).toBe(20);
     });
   });
+
+  it("still belongs to the outer suite", [&]() {
+    expect(v).toEqual(10);
+  });
 });

--- a/test/framework/randomized-tests.test.cpp
+++ b/test/framework/randomized-tests.test.cpp
@@ -20,7 +20,8 @@ describe("randomized tests", []() {
     root_suite.test_cases.push_back(&b);
     child_suite.test_cases.push_back(&c);
     child_suite.test_cases.push_back(&d);
-    root_suite.test_suites["child"] = &child_suite;
+    child_suite.name = "child";
+    root_suite.test_suites.push_back(&child_suite);
 
     cest::randomizeTests(&root_suite, seed, fn);
 


### PR DESCRIPTION
`describeFn` never restored `current_test_suite` after running a suite body, so suites were mis-nested. This fixes it:

- Restore the parent scope after each `describe`; root is an unnamed container and every `describe` is a child of its parent (top-level ones become siblings).
- `test_suites`: `std::map` → `std::vector`, preserving declaration order.
- Reject duplicate sibling names (run exits non-zero).
- Tree/JSON output skip the unnamed root.

Regression test added in `nested-suites.test.cpp`. Siblings and duplicate rejection aren't covered: they only differ in the reported tree/exit code, not runtime behaviour, so they'd need an e2e fixture the repo doesn't have yet.